### PR TITLE
update response model

### DIFF
--- a/cocktail/model.go
+++ b/cocktail/model.go
@@ -3,12 +3,11 @@ package cocktail
 import "database/sql"
 
 type Cocktail struct {
-	ID        int64      `json:"id"`
-	Name      string     `json:"name"`
-	ImageURL  string     `json:"image_url"`
-	CreatedAt int64      `json:"created_at"`
-	UpdatedAt int64      `json:"updated_at"`
-	Materials []Material `json:"materials"`
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	ImageURL  string `json:"image_url"`
+	CreatedAt int64  `json:"created_at"`
+	UpdatedAt int64  `json:"updated_at"`
 }
 
 type NullableCocktail struct {
@@ -17,7 +16,15 @@ type NullableCocktail struct {
 	ImageURL  sql.NullString
 	CreatedAt int64
 	UpdatedAt int64
-	Materials []Material
+}
+
+type CocktailsDetail struct {
+	ID        int64      `json:"id"`
+	Name      string     `json:"name"`
+	ImageURL  string     `json:"image_url"`
+	Materials []Material `json:"materials"`
+	CreatedAt int64      `json:"created_at"`
+	UpdatedAt int64      `json:"updated_at"`
 }
 
 type Material struct {

--- a/cocktail/repository.go
+++ b/cocktail/repository.go
@@ -10,7 +10,7 @@ import (
 
 type Repository interface {
 	GetLimit(ctx context.Context, limit int64, offset int64, keyword string) ([]Cocktail, error)
-	Create(ctx context.Context, params CocktailsParams) (*Cocktail, error)
+	Create(ctx context.Context, params CocktailsParams) (*CocktailsDetail, error)
 }
 
 type CocktailsParams struct {
@@ -58,7 +58,6 @@ func (r CocktailsRepository) GetLimit(ctx context.Context, limit int64, offset i
 			ID:        nc.ID,
 			Name:      nc.Name,
 			ImageURL:  nc.ImageURL.String,
-			Materials: nc.Materials,
 			CreatedAt: nc.CreatedAt,
 			UpdatedAt: nc.CreatedAt,
 		}
@@ -72,7 +71,7 @@ func (r CocktailsRepository) GetLimit(ctx context.Context, limit int64, offset i
 	return cocktails, nil
 }
 
-func (r CocktailsRepository) Create(ctx context.Context, params CocktailsParams) (*Cocktail, error) {
+func (r CocktailsRepository) Create(ctx context.Context, params CocktailsParams) (*CocktailsDetail, error) {
 	log.Printf("create cocktails...")
 
 	tx, err := db.DB.BeginTx(ctx, nil)
@@ -143,7 +142,7 @@ func (r CocktailsRepository) Create(ctx context.Context, params CocktailsParams)
 		return nil, err
 	}
 
-	return &Cocktail{
+	return &CocktailsDetail{
 		ID:        cocktailID,
 		Name:      params.Name,
 		Materials: materials,


### PR DESCRIPTION
レスポンスの修正

- `GET /cocktails`
  - materialsフィールドを削除

もともとmaterialsフィールドをつけていたが、一覧取得のエンドポイントで詳細までは必要なく、余計なクエリを書かないため削除した
